### PR TITLE
feat: print to `stdout` when no file is provided

### DIFF
--- a/cmd/issue2md/main.go
+++ b/cmd/issue2md/main.go
@@ -73,7 +73,11 @@ func main() {
 	}
 
 	if markdownFile == "" {
-		markdownFile = fmt.Sprintf("%s_%s_%s_%d.md", owner, repo, issueType, issueNumber)
+		if _, err := io.WriteString(os.Stdout, markdown); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing to stdout: %v\n", err)
+			os.Exit(1)
+		}
+		return
 	}
 
 	file, err := os.Create(markdownFile)


### PR DESCRIPTION
This change will facilitate the use of the tool in MCP servers, and immutable environments (Docker, etc) but also to pipe the result of the command with another tool.