### PR TITLE
feat: Add support for converting Pull Requests

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,6 +1,6 @@
 # issue2md
 
-一个命令行和网页工具，用于将GitHub issue转换为Markdown格式文件。
+一个命令行和网页工具，用于将GitHub issue、discussion或pull request转换为Markdown格式文件。
 
 >此仓库中的大部分内容是由人工智能生成的!
 
@@ -12,12 +12,12 @@
 $ go install github.com/bigwhite/issue2md/cmd/issue2md@latest
 ```
 
-### 将issue转换为Markdown
+### 将 Issue/Discussion/Pull Request 转换为Markdown
 
 ```
-用法: issue2md [flags] issue-url [markdown-file]
+用法: issue2md [flags] url [markdown-file]
 参数:
-  issue-url      要转换的GitHub issue的URL。
+  url            要转换的GitHub issue、discussion或pull request的URL。
   markdown-file  (可选) 输出的Markdown文件。
 标志:
   -enable-reactions
@@ -32,23 +32,23 @@ $ go install github.com/bigwhite/issue2md/cmd/issue2md@latest
 
 #### 基于Docker镜像运行(推荐)
 
-```                              
+```
 $docker run -d -p 8080:8080 bigwhite/issue2mdweb
-```        
+```
 
 #### 从源码构建安装
 
 ```
 $ git clone https://github.com/bigwhite/issue2md.git
 $ make web
-$ ./issue2mdweb   
+$ ./issue2mdweb
 服务器正在运行在 http://0.0.0.0:8080
 ```
 
-### 将问题转换为 Markdown
+### 将内容转换为 Markdown
 
 在浏览器中打开 localhost:8080：
 
 ![](./screen-snapshot.png)
 
-输入您想要转换的问题URL，然后点击“Convert”按钮！
+输入您想要转换的 issue、discussion 或 pull request 的URL，然后点击“Convert”按钮！

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # issue2md
 
-A CLI and web tool to convert GitHub issues or discussions into Markdown format.
+A CLI and web tool to convert GitHub issues, discussions, or pull requests into Markdown format.
 
 [中文文档](./README-zh.md)
 
@@ -14,12 +14,12 @@ A CLI and web tool to convert GitHub issues or discussions into Markdown format.
 $ go install github.com/bigwhite/issue2md/cmd/issue2md@latest
 ```
 
-### Convert an Issue/Discussion to Markdown
+### Convert an Issue/Discussion/Pull Request to Markdown
 
 ```bash
-Usage: issue2md [flags] issue-url [markdown-file]
+Usage: issue2md [flags] url [markdown-file]
 Arguments:
-  issue-url      The URL of the GitHub issue/discussion to convert.
+  url            The URL of the GitHub issue, discussion, or pull request to convert.
   markdown-file  (optional) The output markdown file.
 Flags:
   -enable-reactions
@@ -47,10 +47,10 @@ $ ./issue2mdweb
 Server is running on http://0.0.0.0:8080
 ```
 
-### Convert an Issue/Discussion to Markdown
+### Convert an Item to Markdown
 
 Open `localhost:8080` in your browser:
 
 ![Screenshot](./screen-snapshot.png)
 
-Input the issue/discussion URL you wish to convert and click the "Convert" button!
+Input the issue, discussion, or pull request URL you wish to convert and click the "Convert" button!

--- a/cmd/issue2md/main.go
+++ b/cmd/issue2md/main.go
@@ -14,9 +14,9 @@ var enableReactions = flag.Bool("enable-reactions", false, "Include reactions in
 var enableUserLinks = flag.Bool("enable-user-links", false, "Enable user profile links in the output.")
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "Usage: issue2md [flags] issue-url [markdown-file]\n")
+	fmt.Fprintf(os.Stderr, "Usage: issue2md [flags] url [markdown-file]\n")
 	fmt.Fprintf(os.Stderr, "Arguments:\n")
-	fmt.Fprintf(os.Stderr, "  issue-url           The URL of the GitHub issue to convert.\n")
+	fmt.Fprintf(os.Stderr, "  url                 The URL of the GitHub issue, discussion, or pull request to convert.\n")
 	fmt.Fprintf(os.Stderr, "  markdown-file       (optional) The output markdown file.\n")
 	fmt.Fprintf(os.Stderr, "Flags:\n")
 	flag.PrintDefaults()
@@ -28,49 +28,64 @@ func main() {
 
 	args := flag.Args()
 	if len(args) < 1 {
-		fmt.Println("Error: issue-url is required.")
+		fmt.Println("Error: url is required.")
 		usage()
 		return
 	}
 
-	issueURL := args[0]
+	itemURL := args[0]
 	var markdownFile string
 	if len(args) >= 2 {
 		markdownFile = args[1]
 	}
 
-	owner, repo, issueNumber, issueType, err := github.ParseURL(issueURL)
+	owner, repo, itemNumber, itemType, err := github.ParseURL(itemURL)
 	if err != nil {
-		fmt.Printf("Error parsing issue URL: %v\n", err)
+		fmt.Printf("Error parsing URL: %v\n", err)
 		return
 	}
 
 	token := os.Getenv("GITHUB_TOKEN")
 
 	var markdown string
-	switch issueType {
+	switch itemType {
 	case "issue":
-		issue, err := github.FetchIssue(owner, repo, issueNumber, token)
+		issue, err := github.FetchIssue(owner, repo, itemNumber, token)
 		if err != nil {
 			fmt.Printf("Error fetching issue: %v\n", err)
 			return
 		}
 
-		comments, err := github.FetchComments(owner, repo, issueNumber, token, *enableReactions, *enableUserLinks)
+		comments, err := github.FetchComments(owner, repo, itemNumber, token, *enableReactions, *enableUserLinks)
 		if err != nil {
 			fmt.Printf("Error fetching comments: %v\n", err)
 			return
 		}
 		markdown = converter.IssueToMarkdown(issue, comments, *enableUserLinks)
 
+	case "pull":
+		pullRequest, err := github.FetchPullRequest(owner, repo, itemNumber, token)
+		if err != nil {
+			fmt.Printf("Error fetching pull request: %v\n", err)
+			return
+		}
+
+		// Pull Request comments are fetched via the issues API endpoint
+		comments, err := github.FetchComments(owner, repo, itemNumber, token, *enableReactions, *enableUserLinks)
+		if err != nil {
+			fmt.Printf("Error fetching comments: %v\n", err)
+			return
+		}
+		markdown = converter.PullRequestToMarkdown(pullRequest, comments, *enableUserLinks)
+
 	case "discussion":
-		discussion, err := github.FetchDiscussion(owner, repo, issueNumber, token)
+		discussion, err := github.FetchDiscussion(owner, repo, itemNumber, token)
 		if err != nil {
 			fmt.Printf("Error fetching discussion: %v\n", err)
 			return
 		}
 
-		discussionComments, err := github.FetchDiscussionComments(owner, repo, issueNumber, token, *enableReactions)
+		discussionComments, err := github.FetchDiscussionComments(owner, repo, itemNumber, token, *enableReactions)
 		if err != nil {
 			fmt.Printf("Error fetching discussion comments: %v\n", err)
 			return
@@ -78,7 +93,7 @@ func main() {
 		markdown = converter.DiscussionToMarkdown(discussion, discussionComments, *enableUserLinks)
 
 	default:
-		fmt.Printf("Unsupported URL type: %s\n", issueType)
+		fmt.Printf("Unsupported URL type: %s\n", itemType)
 		return
 	}
 
@@ -103,5 +118,5 @@ func main() {
 		return
 	}
 
-	fmt.Printf("Issue and comments saved as Markdown in file %s\n", markdownFile)
+	fmt.Printf("Content saved as Markdown in file %s\n", markdownFile)
 }

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -72,6 +72,26 @@ func IssueToMarkdown(issue *github.Issue, comments []github.Comment, enableUserL
 	return sb.String()
 }
 
+func PullRequestToMarkdown(pr *github.PullRequest, comments []github.Comment, enableUserLinks bool) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("# %s\n\n", pr.Title))
+	sb.WriteString(fmt.Sprintf("**Pull Request Number**: #%d\n", pr.Number))
+	sb.WriteString(fmt.Sprintf("**URL**: %s\n", pr.URL))
+	sb.WriteString(fmt.Sprintf("**Created by**: %s\n\n", formatUser(pr.User.Login, enableUserLinks)))
+	sb.WriteString(fmt.Sprintf("## Description\n\n%s\n\n", pr.Body))
+
+	if len(comments) > 0 {
+		sb.WriteString("## Comments\n\n")
+		for i, comment := range comments {
+			writeComment(&sb, i, comment.User, comment.Body, enableUserLinks)
+			writeReactions(&sb, comment.Reactions, enableUserLinks)
+		}
+	}
+
+	return sb.String()
+}
+
 func DiscussionToMarkdown(discussion *github.Discussion, discussionComments []github.DiscussionComment, enableUserLinks bool) string {
 	var sb strings.Builder
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Github Issue or Discussion To Markdown</title>
+    <title>Github Item To Markdown</title>
     <link rel="stylesheet" href="/static/css/styles.css">
 </head>
 <body>
     <div class="container">
         <img src="/static/img/icon.svg" alt="Icon" class="icon">
-        <h1>Github Issue or Discussion To Markdown</h1>
+        <h1>Github Issue, Discussion, or Pull Request To Markdown</h1>
         <form action="/convert" method="post">
-            <input type="text" name="issue_url" placeholder="https://github.com/owner/repo/issues/number" required>
+            <input type="text" name="issue_url" placeholder="https://github.com/owner/repo/issues_or_pull/number" required>
             <button type="submit">Convert</button>
         </form>
     </div>


### PR DESCRIPTION
This commit introduces the capability to convert GitHub Pull Requests into Markdown format, extending the tool's functionality beyond just Issues and Discussions.

This new feature is implemented across both the command-line interface and the web application.

Key changes include:
- A new `FetchPullRequest` function to retrieve PR data from the GitHub API.
- A `PullRequestToMarkdown` converter to format the fetched data.
- Updated URL parsing logic in `ParseURL` to correctly identify and handle Pull Request URLs.
- Integration of the new functionality into the main logic for both the CLI and web handler.
- Documentation (`README.md`, `README-zh.md`) and web UI text have been updated to reflect the inclusion of Pull Request support.
- Renamed variables like `issueURL` to the more generic `itemURL` throughout the codebase for better clarity.