### PR TITLE
issue2md: transform the output header into a list

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -56,9 +56,9 @@ func IssueToMarkdown(issue *github.Issue, comments []github.Comment, enableUserL
 	var sb strings.Builder
 
 	sb.WriteString(fmt.Sprintf("# %s\n\n", issue.Title))
-	sb.WriteString(fmt.Sprintf("**Issue Number**: #%d\n", issue.Number))
-	sb.WriteString(fmt.Sprintf("**URL**: %s\n", issue.URL))
-	sb.WriteString(fmt.Sprintf("**Created by**: %s\n\n", formatUser(issue.User.Login, enableUserLinks)))
+	sb.WriteString(fmt.Sprintf("- **Issue Number**: #%d\n", issue.Number))
+	sb.WriteString(fmt.Sprintf("- **URL**: %s\n", issue.URL))
+	sb.WriteString(fmt.Sprintf("- **Created by**: %s\n\n", formatUser(issue.User.Login, enableUserLinks)))
 	sb.WriteString(fmt.Sprintf("## Description\n\n%s\n\n", issue.Body))
 
 	if len(comments) > 0 {
@@ -76,9 +76,9 @@ func PullRequestToMarkdown(pr *github.PullRequest, comments []github.Comment, en
 	var sb strings.Builder
 
 	sb.WriteString(fmt.Sprintf("# %s\n\n", pr.Title))
-	sb.WriteString(fmt.Sprintf("**Pull Request Number**: #%d\n", pr.Number))
-	sb.WriteString(fmt.Sprintf("**URL**: %s\n", pr.URL))
-	sb.WriteString(fmt.Sprintf("**Created by**: %s\n\n", formatUser(pr.User.Login, enableUserLinks)))
+	sb.WriteString(fmt.Sprintf("- **Pull Request Number**: #%d\n", pr.Number))
+	sb.WriteString(fmt.Sprintf("- **URL**: %s\n", pr.URL))
+	sb.WriteString(fmt.Sprintf("- **Created by**: %s\n\n", formatUser(pr.User.Login, enableUserLinks)))
 	sb.WriteString(fmt.Sprintf("## Description\n\n%s\n\n", pr.Body))
 
 	if len(comments) > 0 {


### PR DESCRIPTION
This will make [`prettier`](https://prettier.io/) happy when reformatting the files.

Currently, the header of a MD file is:

```
# Proposal: Update the NixOS logo for Ukrainian Flag Day (23 August)

**Issue Number**: #1830
**URL**: https://github.com/NixOS/nixos-homepage/issues/1830
**Created by**: [drupol](https://github.com/drupol)
```

However, when reformatting the file with [`prettier`](https://prettier.io/), it becomes:

```
# Proposal: Update the NixOS logo for Ukrainian Flag Day (23 August)

**Issue Number**: #1830 **URL**:
https://github.com/NixOS/nixos-homepage/issues/1830 **Created by**:
[drupol](https://github.com/drupol)
``` 

To fix the issue, we should either add a blank line between each line or use a list. I decided to use a list in this PR.
